### PR TITLE
Putting Console messages behind debug flag

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -114,7 +114,7 @@
                         case 'server' :
                             this.options.debug && console.log('emmiting %s event on %s'.grey, parsedEvent.type, parsedEvent.source);
 
-                            console.log(JSON.stringify(args));
+                            self.options.debug && console.log(JSON.stringify(args));
                             self.proxy.phantom.emit.apply(self.proxy.phantom, args);
                             break;
                         default :
@@ -135,7 +135,7 @@
                 }
             };
 
-            console.log(self.proxy.phantom.addCookie);
+            self.options.debug && console.log(self.proxy.phantom.addCookie);
 
             //create event stream
             fs.open(options.eventStreamPath, 'w+', function (err, fd) {
@@ -209,7 +209,7 @@
                         self.options.debug && console.log('creating a new server, waiting for servercreated event on %s',self.proxy.phantom);
 
                         self.proxy.phantom.on('serverCreated', function (result) {
-                            console.log('server created callback fired with value:%s'.yellow.bold, result);
+                            self.options.debug && console.log('server created callback fired with value:%s'.yellow.bold, result);
                             callbackFn(self.proxy);
                         });
 


### PR DESCRIPTION
Hi, I noticed a few stray `console.log` messages, this makes them appear only when `debug: true`.
