### PR TITLE
Event object uses event as documented, not type

### DIFF
--- a/lib/webpage.js
+++ b/lib/webpage.js
@@ -76,7 +76,7 @@
                         [
                             '/page/functions/sendEvent',
                             callbackFn,
-                            eventArgs.type
+                            eventArgs.event
                         ];
 
                     if(eventArgs.mouseX && eventArgs.mouseY) {


### PR DESCRIPTION
Part of a small erroneous merge issue in ad6647c9 < should have been in
there

just to clarify, your docs show you using { event: 'keypress' } and that's what the code uses as well, like in `test/webpage.spec.js` - it's all `{ event: ' ... ' }` in sendEvent you try to pull the key `type`, I suppose you could change all the other references to type, but since it's documented as event, i'm making this change. it was supposed to be in the referenced commit.
