### PR TITLE
Implementing page.settings.set and page.settings.get

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,29 @@ sets property on page object
 
 ```javascript
   //set viewport size for browser window
-  proxy.page.set('viewportSize',
-  { width:320, height:480 }, function (result) {
-      console.log(result.toString().cyan);
-      worldCallback.call(self);
+  proxy.page.set('viewportSize', { width:320, height:480 }, function (result) {
+      console.log(result.toString());
+  });
+```
+
+### get(propertyName, callbackFn)
+gets property on page object
+
+### settings.set(propertyName, propertyValue, callbackFn)
+sets setting on page object
+
+```javascript
+  proxy.page.settings.set('userAgent', 'iPad', function (result) {
+      console.log(result.toString());
+  });
+```
+
+### settings.set(propertyName, callbackFn)
+gets a setting on page object
+
+```javascript
+  proxy.page.settings.get('userAgent', function (result) {
+      console.log(result.toString());
   });
 ```
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -23,10 +23,8 @@
         //used to translate property to cmd line arg
         var argMap = {
             'ignoreSslErrors':'ignore-ssl-errors',
-            'localToRemoteUrlAccessEnabled':'local-to-remote-url-access',
             'cookiesFile':'cookies-file',
             'diskCache':'disk-cache',
-            'loadImages':'load-images',
             'maxDiskCache':'max-disk-cache',
             'outputEncoding':'output-encoding',
             'proxy':'proxy',
@@ -35,23 +33,6 @@
             'version':'version',
             'webSecurity':'web-security',
             'port':'port'
-        };
-
-        //may integrate in future
-        var defaultoptions = {
-            'ignoreSslErrors':true,
-            'localToRemoteUrlAccessEnabled':true,
-            'cookiesFile':'cookies.txt',
-            'diskCache':'yes',
-            'loadImages':'yes',
-            'localToRemoteUrlAccess':'no',
-            'maxDiskCache':'50000',
-            'outputEncoding':'utf8',
-            'proxy':'0',
-            'proxyType':'yes',
-            'scriptEncoding':'yes',
-            'webSecurity':'no',
-            'port':1061
         };
 
         //map options props to cmd line args for phantom process

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -140,6 +140,16 @@
                             break;
                     }
                     break;
+                case 'settings' :
+                    switch (segments.controller) {
+                        case 'get':
+                            resource.getSetting(request.post.propertyName);
+                            break;
+                        case 'set':
+                            resource.setSetting(request.post.propertyName, request.post.propertyValue);
+                            break;
+                    }
+                    break;
             }
         }
     };

--- a/lib/server/webpage.js
+++ b/lib/server/webpage.js
@@ -34,6 +34,32 @@
                 self.response.close();
             }
         },
+        setSetting:function (propertyName, propertyValue) {
+            var self = this;
+            try {
+                this.page.settings[propertyName] = JSON.parse(propertyValue);
+                this.response.write(this.page.settings[propertyName]);
+                this.response.statusCode = 200;
+                this.response.close();
+            } catch (ex) {
+                self.response.statusCode = 500;
+                self.response.write(ex.toString());
+                self.response.close();
+            }
+        },
+        getSetting:function (propertyName) {
+            var self = this;
+            try {
+                var result = this.page.settings[propertyName];
+                this.response.write(JSON.stringify(result));
+                this.response.statusCode = 200;
+                this.response.close();
+            } catch (ex) {
+                self.response.statusCode = 500;
+                self.response.write(ex.toString());
+                self.response.close();
+            }
+        },
         setResponse:function (response) {
             this.response = response;
         },

--- a/lib/webpage.js
+++ b/lib/webpage.js
@@ -67,6 +67,39 @@
                             }
                         });
                 },
+                settings: {
+                    set:function (propertyName, propertyValue, callbackFn) {
+                        request.post(self.options.hostAndPort + '/page/settings/set', {
+                            form:{
+                                propertyName:propertyName,
+                                propertyValue:JSON.stringify(propertyValue)
+                            }
+                        },
+                        function (error, response, body) {
+                            if (response && response.statusCode === 200) {
+                                callbackFn && callbackFn.call(self, !!body);
+                            }
+                            else {
+                                callbackFn && callbackFn.call(self, false, body);
+                            }
+                        });
+                    },
+                    get:function (propertyName, callbackFn) {
+                        request.post(self.options.hostAndPort + '/page/settings/get', {form:{propertyName:propertyName}},
+                            function (error, response, body) {
+                                error && console.error(error);
+                                if (response && response.statusCode === 200) {
+                                    console.log('response is ',body, 'code: ',response.statusCode);
+                                    console.log('response parsed: ',JSON.parse(body));
+                                    callbackFn && callbackFn.call(self, JSON.parse(body));
+                                }
+                                else {
+                                    console.log('error in response %s'.red.bold, body);
+                                    callbackFn && callbackFn.call(self, false, body);
+                                }
+                            });
+                    }
+                },
                 includeJs:function (url, callbackFn) {
 
                     executeMethod.call(this, '/page/functions/includeJs', callbackFn, url);

--- a/test/webpage.spec.js
+++ b/test/webpage.spec.js
@@ -132,6 +132,30 @@ describe('page', function () {
             });
         });
     });
+    describe('#settings', function () {
+        describe('#useragent', function () {
+            it('should set useragent', function (done) {
+                phantomProxy.create({"debug":true}, function (proxy) {
+                    should.exist(proxy.page);
+                    proxy.page.settings.set('userAgent', 'iPad', function (result) {
+                        assert.equal(result, true);
+                        done();
+                    });
+                });
+            });
+            it('should get useragent', function (done) {
+                phantomProxy.create({"debug":true}, function (proxy) {
+                    should.exist(proxy.page);
+                    proxy.page.settings.set('userAgent', 'iPad', function (result) {
+                        proxy.page.settings.get('userAgent', function (result) {
+                            assert.equal(result, 'iPad');
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+    });
     it('should render', function (done) {
         this.timeout(0);
         phantomProxy.create({"debug":true}, function (proxy) {


### PR DESCRIPTION
Currently you can set the page **properties** but not the page
**settings**. This patch allows you to do so. Note this does NOT allow
for setting multiple page settings at once. It would be more work, and
this is in line with how page.set works anyway

Please note that I am mad at you now for how much work this took to figure out.
