### PR TITLE
Fixing phantom startup options, none of which ever worked

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -31,13 +31,14 @@
             'proxyType':'proxy-type',
             'scriptEncoding':'script-encoding',
             'version':'version',
-            'webSecurity':'web-security',
-            'port':'port'
+            'webSecurity':'web-security'
         };
 
         //map options props to cmd line args for phantom process
-        return Object.keys(options).map(function (value) {
-            return '--' + argMap[value] + '=' + options[value];
+        return Object.keys(options).map(function(value) {
+            return argMap[value] && '--' + argMap[value] + '=' + options[value];
+        }).filter(function(value) {
+            return !!value;
         });
 
     };
@@ -101,10 +102,10 @@
                 var spawn = require('child_process').spawn,
                     serverPath = __dirname + '/' + require('path').normalize('./server/index.js');
 
-                var processArgs = translateOptions2Arguments(options);
-
-                processArgs.unshift(JSON.stringify(options));
-                processArgs.unshift(serverPath);
+                // First come phantom args, then server args, then marraige...
+                var processArgs = translateOptions2Arguments(options)
+                    .concat(serverPath)
+                    .concat(JSON.stringify(options));
 
                 //spawn new process
                 var phantomjs = spawn('phantomjs',


### PR DESCRIPTION
It seems like if you don't put phantomjs startup options before the js
script name, they won't work. --ignore-ssl-errors needs to come before
index.js essentially
