### PR TITLE
Allow new API for setting a callback method for onConfirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ The following events are supported, see [PhantomJs Docs](https://github.com/ariy
 <tr><td>initialized</td><td></td></tr>
 <tr><td>error</td><td></td></tr>
 <tr><td>consoleMessage</td><td></td></tr>
-<tr><td>confirm</td><td>Event will fire, but callback will not execute in phantomjs context</td></tr>
+<tr><td>confirm</td><td>See onConfirmCallback for handling this event</td></tr>
 <tr><td>closing</td><td></td></tr>
 <tr><td>callback</td><td></td></tr>
 <tr><td>alert</td><td></td></tr>
@@ -273,8 +273,16 @@ phantomProxy.create({}, function (proxy) {
 });
 ```
 
+#### Special events
 
+Some phantomjs functions allow you to return a value to drive phantom interaction. Currently, onConfirm is supported. To register a callback function for intercepting confirm dialogs, use onConfirmCallback:
 
+```javascript
+// return true corresponds to accepting confirm, return false is denying
+proxy.page.set('onConfirmCallback', function(msg) { return true; });
+```
+
+Pre-registering a confirm function can be useful if you encounter a page that prompts you when you try to leave. Without registering a function that returns true, phantomjs will hang. Please note you can still listen for the 'confirm' event in conjunction with this special handler.
 
 ## Revision History
 * 2012-11-06 - version 0.1.6

--- a/lib/server/webpage.js
+++ b/lib/server/webpage.js
@@ -1,5 +1,15 @@
 /*global  module:false, console:false, require:false*/
 (function (module) {
+
+    // return a function instance from a .toString()ed function
+    function parseFn(fn) {
+        var startBody = fn.indexOf('{') + 1,
+            endBody = fn.lastIndexOf('}'),
+            startArgs = fn.indexOf('(') + 1,
+            endArgs = fn.indexOf(')');
+        return new Function(fn.substring(startArgs, endArgs), fn.substring(startBody, endBody));
+    }
+
     'use strict';
     module.exports = {
 
@@ -11,7 +21,12 @@
         setProperty:function (propertyName, propertyValue) {
             var self = this;
             try {
-                this.page[propertyName] = JSON.parse(propertyValue);
+                var parsed = JSON.parse(propertyValue);
+
+                // allow functions to be set, at the moment specifically for
+                // onConfirmCallback function
+                this.page[propertyName] = parsed._fn ?
+                    parseFn(parsed._fn) : parsed;
                 this.response.write(this.page[propertyName]);
                 this.response.statusCode = 200;
                 this.response.close();
@@ -242,8 +257,9 @@
             }
         },
         bindEvents:function (server) {
+            var page = this.page;
 
-            this.page.onAlert = function (message) {
+            page.onAlert = function (message) {
                 var event = {
                     source:'alert',
                     args:
@@ -253,7 +269,7 @@
                 };
                 server.emit('page', event);
             };
-            this.page.onCallback = function (data) {
+            page.onCallback = function (data) {
                 var event = {
                     type:'callback',
                     args:
@@ -264,7 +280,7 @@
 
                 server.emit('page', event);
             };
-            this.page.onClosing = function (closingPage) {
+            page.onClosing = function (closingPage) {
                 var event = {
                     type:'closing',
                     args:
@@ -275,7 +291,7 @@
                 server.emit('page', event);
             };
 
-            this.page.onConfirm = function (msg) {
+            page.onConfirm = function (msg) {
                 var event = {
                     type:'confirm',
                     args:
@@ -284,9 +300,15 @@
                         ]
                 };
                 server.emit('page', event);
+
+                // Allow user specified return function to return true / false
+                // which corresponds to accept / deny confirm box
+                if(page.onConfirmCallback) {
+                    return page.onConfirmCallback.apply(page, arguments);
+                }
             };
             //TODO:capture msg, linenum parms
-            this.page.onConsoleMessage = function (msg, lineNum, typeId) {
+            page.onConsoleMessage = function (msg, lineNum, typeId) {
                 var event = {
                     type:'consoleMessage',
                     args:
@@ -298,7 +320,7 @@
                 };
                 server.emit('page', event);
             };
-            this.page.onError = function (msg, trace) {
+            page.onError = function (msg, trace) {
                 var event = {
                     type:'error',
                     args:
@@ -309,7 +331,7 @@
                 };
                 server.emit('page', event);
             };
-            this.page.onInitialized = function () {
+            page.onInitialized = function () {
                 var event = {
                     type:'initialized',
                     args:
@@ -318,7 +340,7 @@
                 };
                 server.emit('page', event);
             };
-            this.page.onLoadFinished = function (status) {
+            page.onLoadFinished = function (status) {
                 var event = {
                     type:'loadFinished',
                     args:
@@ -328,7 +350,7 @@
                 };
                 server.emit('page', event);
             };
-            this.page.onLoadStarted = function () {
+            page.onLoadStarted = function () {
                 var event = {
                     type:'loadStarted',
                     args:
@@ -338,7 +360,7 @@
                 };
                 server.emit('page', event);
             };
-            this.page.onResourceRequested = function (response) {
+            page.onResourceRequested = function (response) {
                 var event = {
                     type:'resourceRequested',
                     args:
@@ -348,7 +370,7 @@
                 };
                 server.emit('page', event);
             };
-            this.page.onResourceReceived = function (response) {
+            page.onResourceReceived = function (response) {
                 var event = {
                     type:'resourceReceived',
                     args:
@@ -358,7 +380,7 @@
                 };
                 server.emit('page', event);
             };
-            this.page.onNavigationRequested = function (url, type, willNavigate, main) {
+            page.onNavigationRequested = function (url, type, willNavigate, main) {
                 var event = {
                     type:'navigationRequested',
                     args:
@@ -371,7 +393,7 @@
                 };
                 server.emit('page', event);
             };
-            this.page.onPageCreated = function (newPage) {
+            page.onPageCreated = function (newPage) {
                 var event = {
                     type:'pageCreated',
                     args:
@@ -391,7 +413,7 @@
 //                };
 //                logEvent(event);
 //            };
-            this.page.onRetypeReceived = function (response) {
+            page.onRetypeReceived = function (response) {
                 var event = {
                     type:'retypeReceived',
                     args:
@@ -401,7 +423,7 @@
                 };
                 server.emit('page', event);
             };
-            this.page.onUrlChanged = function (page) {
+            page.onUrlChanged = function (page) {
                 var event = {
                     type:'urlChanged',
                     args:

--- a/lib/webpage.js
+++ b/lib/webpage.js
@@ -36,6 +36,14 @@
             _.extend(this, {
                 set:function (propertyName, propertyValue, callbackFn) {
                     var self = this;
+
+                    // allow functions to be set
+                    if(typeof propertyValue === 'function') {
+                        propertyValue = {
+                            _fn: propertyValue.toString()
+                        };
+                    }
+
                     request.post(self.options.hostAndPort + '/page/properties/set', {
                             form:{
                                 propertyName:propertyName,


### PR DESCRIPTION
Phantomjs has an 'onConfirm' event which is the handler for a javascript
confirm dialog. This handler allows you to return true or false which
corresponds to clicking yes / no on the confirm dialog. Without being
able to return, the dialog will block all interaction, including future
page loads. However, by the time userland catches the on('confirm')
event, we are two event loop ticks past the function and are in no place
to return true / false.

This patch allows for a new API function page.set('onConfirmCallback')
which will serialize and deserialize a function into phantom to
pre-register a callback function which will be called on a confirm hit.

It's the simplest way I could think of to achieve this.
