### PR TITLE
Fix phantomjs spawn argument typo 'detatched'.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -145,7 +145,7 @@
                 var phantomjs = spawn('phantomjs',
                     processArgs,
                     {
-                        detatched:false,
+                        detached:false,
                         stdio:
                             [
                                 process.stdin,


### PR DESCRIPTION
Since the value is false and the default is false, no harm for now.
