### PR TITLE
Adding other command line arguments for PhantomJS

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -28,14 +28,19 @@
             'diskCache':'disk-cache',
             'ignoreSslErrors':'ignore-ssl-errors',
             'loadImages':'load-images',
+            'localStoragePath': 'local-storage-path',
+            'localStorageQuota': 'local-storage-quota',
             'localToRemoteUrlAccessEnabled':'local-to-remote-url-access',
             'maxDiskCache':'max-disk-cache-size',
             'outputEncoding':'output-encoding',
             'proxy':'proxy',
+            'proxyAuth': 'proxy-auth',
             'proxyType':'proxy-type',
             'scriptEncoding':'script-encoding',
             'version':'version',
-            'webSecurity':'web-security'
+            'webSecurity':'web-security',
+            'sslProtocol': 'ssl-protocol',
+            'sslCertificatesPath': 'ssl-certificates-path'
         };
 
         //may integrate in future


### PR DESCRIPTION
Added in phantomArgMap lines to allow setting of localStorage, proxyAuth and ssl in the phantomjs commandline
