### PR TITLE
proxy-object should only be created if the server is listening

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -192,7 +192,6 @@
                     </script></head><body></body></html>');
             }).listen();
 
-            options.clientPort = this.server.address().port;
             var io = socketio.listen(this.server, {'log level':1});
 
             io.sockets.on('connection', function (socket) {
@@ -204,18 +203,21 @@
                 });
             });
 
-            //create proxy object
-            self.proxy = {
-                page:new Webpage(options),
-                phantom:new Phantom(options),
-                end:function (endCallback) {
-                    self.end(function () {
-                        endCallback(true);
-                    });
-                }
-            };
+            this.server.on('listening', function () {
+                options.clientPort = self.server.address().port;
+                //create proxy object
+                self.proxy = {
+                    page: new Webpage(options),
+                    phantom: new Phantom(options),
+                    end:function (endCallback) {
+                        self.end(function () {
+                            endCallback(true);
+                        });
+                    }
+                };
+                ensureServerRunning();
+            });
 
-            ensureServerRunning();
         },
 //use to see if  phantom server already runnings
         pingServer = function (options, callbackFn) {


### PR DESCRIPTION
otherwise this module will not work in a clustered application. 

probably the whole ensureServerRunning and pingServer stuff should be removed in proxy.js. i dont see a reason why it shouldn't use all events which a http-Server emits (listening, error, close and so on). i just left it where it is, you decide how you want to handle it
