### PR TITLE
endCallback bug patch

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -210,7 +210,7 @@
                 phantom:new Phantom(options),
                 end:function (endCallback) {
                     self.end(function () {
-                        endCallback(true);
+                        endCallback&&endCallback(true);
                     });
                 }
             };


### PR DESCRIPTION
If argument is not a function, then error occur when proxy.end called.

ex)
proxy.end(); //error
